### PR TITLE
Correct initialization of directory names

### DIFF
--- a/github-sectory
+++ b/github-sectory
@@ -75,13 +75,13 @@ class GithubSectory():
 		
 		else:
 			puts(colored.magenta("[ Validating Input URL ]"))
-			if len(self.link.split("/")) < 7:
+			if len(self.link.split("/")) < 8:
 				puts(colored.green("Normal Link, use git commands to clone repository!"))
 			else:
 				self.link = self.link.replace(self.gh, self.ghapi)
 				self.link = self.link.replace('tree', 'contents')
 				self.linkList = self.link.split("/")
-				self.repo = self.dir = self.linkList[8]
+				self.repo = self.dir = self.linkList[-1]
 				self.link = self.link.replace(self.linkList[7]+"/", '')
 				self.link = self.link + "/?ref=" + self.linkList[7]
 				self.downloadMe(self.link)


### PR DESCRIPTION
@amarlearning The issue was that directory name should be the last item in the list that we get after modifying and then splitting the link name. But you were assigning it the '9th item' in the list.
You can take a look at that in this PR.